### PR TITLE
Multiple instances of parsers

### DIFF
--- a/6/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
+++ b/6/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
@@ -13,11 +13,15 @@ import java.net.URI;
 public class TraveltimeQParserPlugin extends QParserPlugin {
    public static String PARAM_PREFIX = "traveltime_";
    private String cacheName = RequestCache.NAME;
+   private String paramPrefix = PARAM_PREFIX;
 
    @Override
    public void init(NamedList args) {
       Object cache = args.get("cache");
       if (cache != null) cacheName = cache.toString();
+
+      Object prefix = args.get("prefix");
+      if (prefix != null) paramPrefix = prefix.toString();
 
       Object uriVal = args.get("api_uri");
       URI uri = null;
@@ -35,7 +39,8 @@ public class TraveltimeQParserPlugin extends QParserPlugin {
                                        params,
                                        req,
                                        FetcherSingleton.INSTANCE.getFetcher(),
-                                       cacheName
+                                       cacheName,
+                                       paramPrefix
       );
    }
 

--- a/6/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
+++ b/6/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
@@ -7,18 +7,19 @@ import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.search.QParser;
 import org.apache.solr.search.SyntaxError;
 
-import static com.traveltime.plugin.solr.TraveltimeQParserPlugin.PARAM_PREFIX;
-
 public class TraveltimeQueryParser extends QParser {
    private static final String WEIGHT = "weight";
 
    private final ProtoFetcher fetcher;
    private final String cacheName;
 
-   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, ProtoFetcher fetcher, String cacheName) {
+   private final String paramPrefix;
+
+   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, ProtoFetcher fetcher, String cacheName, String paramPrefix) {
       super(qstr, localParams, params, req);
       this.fetcher = fetcher;
       this.cacheName = cacheName;
+      this.paramPrefix = paramPrefix;
    }
 
    private String getBestParam(String name) throws SyntaxError {
@@ -26,10 +27,10 @@ public class TraveltimeQueryParser extends QParser {
       if (localParams != null) {
          param = localParams.get(name);
          if (param != null) return param;
-         param = localParams.get(PARAM_PREFIX + name);
+         param = localParams.get(paramPrefix + name);
          if (param != null) return param;
       }
-      param = params.get(PARAM_PREFIX + name);
+      param = params.get(paramPrefix + name);
       if (param != null) return param;
       param = params.get(name);
       if (param != null) return param;

--- a/6/src/main/java/com/traveltime/plugin/solr/query/TraveltimeValueSourceParser.java
+++ b/6/src/main/java/com/traveltime/plugin/solr/query/TraveltimeValueSourceParser.java
@@ -16,15 +16,20 @@ import static com.traveltime.plugin.solr.TraveltimeQParserPlugin.PARAM_PREFIX;
 public class TraveltimeValueSourceParser extends ValueSourceParser {
    private String cacheName = RequestCache.NAME;
 
+   private String paramPrefix = PARAM_PREFIX;
+
    @Override
    public void init(NamedList args) {
       super.init(args);
       Object cache = args.get("cache");
       if (cache != null) cacheName = cache.toString();
+
+      Object prefix = args.get("prefix");
+      if (prefix != null) paramPrefix = prefix.toString();
    }
 
    private String getParam(SolrParams params, String name) throws SyntaxError {
-      String param = params.get(PARAM_PREFIX + name);
+      String param = params.get(paramPrefix + name);
       if (param != null) return param;
       param = params.get(name);
       if (param != null) return param;

--- a/7/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
+++ b/7/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
@@ -13,6 +13,7 @@ import java.net.URI;
 public class TraveltimeQParserPlugin extends QParserPlugin {
    public static String PARAM_PREFIX = "traveltime_";
    private String cacheName = RequestCache.NAME;
+   private String paramPrefix = PARAM_PREFIX;
 
    @Override
    public void init(NamedList args) {
@@ -35,8 +36,8 @@ public class TraveltimeQParserPlugin extends QParserPlugin {
                                        params,
                                        req,
                                        FetcherSingleton.INSTANCE.getFetcher(),
-                                       cacheName
-      );
+                                       cacheName,
+              paramPrefix);
    }
 
 }

--- a/7/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
+++ b/7/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
@@ -7,18 +7,18 @@ import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.search.QParser;
 import org.apache.solr.search.SyntaxError;
 
-import static com.traveltime.plugin.solr.TraveltimeQParserPlugin.PARAM_PREFIX;
-
 public class TraveltimeQueryParser extends QParser {
    private static final String WEIGHT = "weight";
 
    private final ProtoFetcher fetcher;
    private final String cacheName;
+   private final String paramPrefix;
 
-   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, ProtoFetcher fetcher, String cacheName) {
+   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, ProtoFetcher fetcher, String cacheName, String paramPrefix) {
       super(qstr, localParams, params, req);
       this.fetcher = fetcher;
       this.cacheName = cacheName;
+      this.paramPrefix = paramPrefix;
    }
 
    private String getBestParam(String name) throws SyntaxError {
@@ -26,10 +26,10 @@ public class TraveltimeQueryParser extends QParser {
       if (localParams != null) {
          param = localParams.get(name);
          if (param != null) return param;
-         param = localParams.get(PARAM_PREFIX + name);
+         param = localParams.get(paramPrefix + name);
          if (param != null) return param;
       }
-      param = params.get(PARAM_PREFIX + name);
+      param = params.get(paramPrefix + name);
       if (param != null) return param;
       param = params.get(name);
       if (param != null) return param;

--- a/7/src/main/java/com/traveltime/plugin/solr/query/TraveltimeValueSourceParser.java
+++ b/7/src/main/java/com/traveltime/plugin/solr/query/TraveltimeValueSourceParser.java
@@ -15,16 +15,20 @@ import static com.traveltime.plugin.solr.TraveltimeQParserPlugin.PARAM_PREFIX;
 
 public class TraveltimeValueSourceParser extends ValueSourceParser {
    private String cacheName = RequestCache.NAME;
+   private String paramPrefix = PARAM_PREFIX;
 
    @Override
    public void init(NamedList args) {
       super.init(args);
       Object cache = args.get("cache");
       if (cache != null) cacheName = cache.toString();
+
+      Object prefix = args.get("prefix");
+      if (prefix != null) paramPrefix = prefix.toString();
    }
 
    private String getParam(SolrParams params, String name) throws SyntaxError {
-      String param = params.get(PARAM_PREFIX + name);
+      String param = params.get(paramPrefix + name);
       if (param != null) return param;
       param = params.get(name);
       if (param != null) return param;

--- a/8/src/main/java/com/traveltime/plugin/solr/TimeFilterQParserPlugin.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/TimeFilterQParserPlugin.java
@@ -12,8 +12,12 @@ import org.apache.solr.search.QParserPlugin;
 import java.net.URI;
 import java.util.Optional;
 
+import static com.traveltime.plugin.solr.query.ParamSource.PARAM_PREFIX;
+
 public class TimeFilterQParserPlugin extends QParserPlugin {
    private String cacheName = RequestCache.NAME;
+
+   private String paramPrefix = PARAM_PREFIX;
 
    private static final Integer DEFAULT_LOCATION_SIZE_LIMIT = 2000;
 
@@ -21,6 +25,9 @@ public class TimeFilterQParserPlugin extends QParserPlugin {
    public void init(NamedList args) {
       Object cache = args.get("cache");
       if (cache != null) cacheName = cache.toString();
+
+      Object prefix = args.get("prefix");
+      if (prefix != null) paramPrefix = prefix.toString();
 
       Object uriVal = args.get("api_uri");
       URI uri = null;
@@ -43,7 +50,8 @@ public class TimeFilterQParserPlugin extends QParserPlugin {
                                        params,
                                        req,
                                        JsonFetcherSingleton.INSTANCE.getFetcher(),
-                                       cacheName
+                                       cacheName,
+                                       paramPrefix
       );
    }
 

--- a/8/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
@@ -11,13 +11,20 @@ import org.apache.solr.search.QParserPlugin;
 
 import java.net.URI;
 
+import static com.traveltime.plugin.solr.query.ParamSource.PARAM_PREFIX;
+
 public class TraveltimeQParserPlugin extends QParserPlugin {
    private String cacheName = RequestCache.NAME;
+
+   private String paramPrefix = PARAM_PREFIX;
 
    @Override
    public void init(NamedList args) {
       Object cache = args.get("cache");
       if (cache != null) cacheName = cache.toString();
+
+      Object prefix = args.get("prefix");
+      if (prefix != null) paramPrefix = prefix.toString();
 
       Object uriVal = args.get("api_uri");
       URI uri = null;
@@ -35,7 +42,8 @@ public class TraveltimeQParserPlugin extends QParserPlugin {
                                        params,
                                        req,
                                        ProtoFetcherSingleton.INSTANCE.getFetcher(),
-                                       cacheName
+                                       cacheName,
+                                       paramPrefix
       );
    }
 

--- a/8/src/main/java/com/traveltime/plugin/solr/query/ParamSource.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/query/ParamSource.java
@@ -7,11 +7,14 @@ import org.apache.solr.search.SyntaxError;
 import java.util.Optional;
 
 public class ParamSource {
+    private final String paramPrefix;
+
    private final SolrParams[] params;
 
    public static final String PARAM_PREFIX = "traveltime_";
 
-   public ParamSource(SolrParams... params) {
+    public ParamSource(String paramPrefix, SolrParams... params) {
+      this.paramPrefix = paramPrefix;
       this.params = params;
    }
 
@@ -22,7 +25,7 @@ public class ParamSource {
    public Optional<String> getOptionalParam(String name) {
       String param;
       for (val source : params) {
-         param = source.get(PARAM_PREFIX + name);
+            param = source.get(paramPrefix + name);
          if (param != null) return Optional.of(param);
          param = source.get(name);
          if (param != null) return Optional.of(param);

--- a/8/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
@@ -12,16 +12,18 @@ public class TraveltimeQueryParser extends QParser {
 
    private final Fetcher<TraveltimeQueryParameters> fetcher;
    private final String cacheName;
+   private final String paramPrefix;
 
-   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, Fetcher<TraveltimeQueryParameters> fetcher, String cacheName) {
+   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, Fetcher<TraveltimeQueryParameters> fetcher, String cacheName, String paramPrefix) {
       super(qstr, localParams, params, req);
       this.fetcher = fetcher;
       this.cacheName = cacheName;
+      this.paramPrefix = paramPrefix;
    }
 
    @Override
    public TraveltimeSearchQuery<TraveltimeQueryParameters> parse() throws SyntaxError {
-      ParamSource paramSource = new ParamSource(localParams, params);
+      ParamSource paramSource = new ParamSource(paramPrefix, localParams, params);
       float weight;
       try {
          weight = Float.parseFloat(paramSource.getParam(WEIGHT));

--- a/8/src/main/java/com/traveltime/plugin/solr/query/TraveltimeValueSourceParser.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/query/TraveltimeValueSourceParser.java
@@ -10,14 +10,21 @@ import org.apache.solr.search.FunctionQParser;
 import org.apache.solr.search.SyntaxError;
 import org.apache.solr.search.ValueSourceParser;
 
+import static com.traveltime.plugin.solr.query.ParamSource.PARAM_PREFIX;
+
 public class TraveltimeValueSourceParser extends ValueSourceParser {
    private String cacheName = RequestCache.NAME;
+
+   private String paramPrefix = PARAM_PREFIX;
 
    @Override
    public void init(NamedList args) {
       super.init(args);
       Object cache = args.get("cache");
       if (cache != null) cacheName = cache.toString();
+
+      Object prefix = args.get("prefix");
+      if (prefix != null) paramPrefix = prefix.toString();
    }
 
    @Override
@@ -32,7 +39,7 @@ public class TraveltimeValueSourceParser extends ValueSourceParser {
          );
       }
 
-      val queryParameters = TraveltimeQueryParameters.parse(req.getSchema(), new ParamSource(fp.getParams()));
+      val queryParameters = TraveltimeQueryParameters.parse(req.getSchema(), new ParamSource(paramPrefix, fp.getParams()));
       return new TraveltimeValueSource<>(queryParameters, cache.getOrFresh(queryParameters));
    }
 }

--- a/8/src/main/java/com/traveltime/plugin/solr/query/timefilter/TimeFilterQueryParser.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/query/timefilter/TimeFilterQueryParser.java
@@ -14,16 +14,18 @@ public class TimeFilterQueryParser extends QParser {
 
    private final Fetcher<TimeFilterQueryParameters> fetcher;
    private final String cacheName;
+   private final String paramPrefix;
 
-   public TimeFilterQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, Fetcher<TimeFilterQueryParameters> fetcher, String cacheName) {
+   public TimeFilterQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, Fetcher<TimeFilterQueryParameters> fetcher, String cacheName, String paramPrefix) {
       super(qstr, localParams, params, req);
       this.fetcher = fetcher;
       this.cacheName = cacheName;
+      this.paramPrefix = paramPrefix;
    }
 
    @Override
    public TraveltimeSearchQuery<TimeFilterQueryParameters> parse() throws SyntaxError {
-      ParamSource paramSource = new ParamSource(localParams, params);
+      ParamSource paramSource = new ParamSource(paramPrefix, localParams, params);
       float weight;
       try {
          weight = Float.parseFloat(paramSource.getParam(WEIGHT));

--- a/8/src/main/java/com/traveltime/plugin/solr/query/timefilter/TimeFilterValueSourceParser.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/query/timefilter/TimeFilterValueSourceParser.java
@@ -11,14 +11,21 @@ import org.apache.solr.search.FunctionQParser;
 import org.apache.solr.search.SyntaxError;
 import org.apache.solr.search.ValueSourceParser;
 
+import static com.traveltime.plugin.solr.query.ParamSource.PARAM_PREFIX;
+
 public class TimeFilterValueSourceParser extends ValueSourceParser {
    private String cacheName = RequestCache.NAME;
+
+   private String paramPrefix = PARAM_PREFIX;
 
    @Override
    public void init(NamedList args) {
       super.init(args);
       Object cache = args.get("cache");
       if (cache != null) cacheName = cache.toString();
+
+      Object prefix = args.get("prefix");
+      if (prefix != null) paramPrefix = prefix.toString();
    }
 
    @Override
@@ -34,7 +41,7 @@ public class TimeFilterValueSourceParser extends ValueSourceParser {
       }
 
       TimeFilterQueryParameters queryParams = TimeFilterQueryParameters.parse(req.getSchema(),
-                                                                              new ParamSource(fp.getParams())
+                                                                              new ParamSource(paramPrefix, fp.getParams())
       );
       return new TraveltimeValueSource<>(queryParams, cache.getOrFresh(queryParams));
    }

--- a/9/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
+++ b/9/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
@@ -13,6 +13,7 @@ import java.net.URI;
 public class TraveltimeQParserPlugin extends QParserPlugin {
    public static String PARAM_PREFIX = "traveltime_";
    private String cacheName = RequestCache.NAME;
+   private String paramPrefix = PARAM_PREFIX;
 
    @Override
    public void init(NamedList args) {
@@ -35,8 +36,8 @@ public class TraveltimeQParserPlugin extends QParserPlugin {
                                        params,
                                        req,
                                        FetcherSingleton.INSTANCE.getFetcher(),
-                                       cacheName
-      );
+                                       cacheName,
+              paramPrefix);
    }
 
 }

--- a/9/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
+++ b/9/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
@@ -7,18 +7,18 @@ import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.search.QParser;
 import org.apache.solr.search.SyntaxError;
 
-import static com.traveltime.plugin.solr.TraveltimeQParserPlugin.PARAM_PREFIX;
-
 public class TraveltimeQueryParser extends QParser {
    private static final String WEIGHT = "weight";
 
    private final ProtoFetcher fetcher;
    private final String cacheName;
+   private final String paramPrefix;
 
-   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, ProtoFetcher fetcher, String cacheName) {
+   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, ProtoFetcher fetcher, String cacheName, String paramPrefix) {
       super(qstr, localParams, params, req);
       this.fetcher = fetcher;
       this.cacheName = cacheName;
+      this.paramPrefix = paramPrefix;
    }
 
    private String getBestParam(String name) throws SyntaxError {
@@ -26,10 +26,10 @@ public class TraveltimeQueryParser extends QParser {
       if (localParams != null) {
          param = localParams.get(name);
          if (param != null) return param;
-         param = localParams.get(PARAM_PREFIX + name);
+         param = localParams.get(paramPrefix + name);
          if (param != null) return param;
       }
-      param = params.get(PARAM_PREFIX + name);
+      param = params.get(paramPrefix + name);
       if (param != null) return param;
       param = params.get(name);
       if (param != null) return param;

--- a/9/src/main/java/com/traveltime/plugin/solr/query/TraveltimeValueSourceParser.java
+++ b/9/src/main/java/com/traveltime/plugin/solr/query/TraveltimeValueSourceParser.java
@@ -15,6 +15,7 @@ import static com.traveltime.plugin.solr.TraveltimeQParserPlugin.PARAM_PREFIX;
 
 public class TraveltimeValueSourceParser extends ValueSourceParser {
    private String cacheName = RequestCache.NAME;
+   private String paramPrefix = PARAM_PREFIX;
 
    @Override
    public void init(NamedList args) {
@@ -24,7 +25,7 @@ public class TraveltimeValueSourceParser extends ValueSourceParser {
    }
 
    private String getParam(SolrParams params, String name) throws SyntaxError {
-      String param = params.get(PARAM_PREFIX + name);
+      String param = params.get(paramPrefix + name);
       if (param != null) return param;
       param = params.get(name);
       if (param != null) return param;


### PR DESCRIPTION
Allow multiple instances of the query and source value parsers to be used in the same Solr query, by using different parameter prefixes.

The changes are backwards compatible. If no prefix is specified, it falls back to `traveltime_`.