### PR TITLE
Add option to disable filtering

### DIFF
--- a/6/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
+++ b/6/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
@@ -13,11 +13,15 @@ import java.net.URI;
 public class TraveltimeQParserPlugin extends QParserPlugin {
    public static String PARAM_PREFIX = "traveltime_";
    private String cacheName = RequestCache.NAME;
+   private boolean isFilteringDisabled = false;
 
    @Override
    public void init(NamedList args) {
       Object cache = args.get("cache");
       if (cache != null) cacheName = cache.toString();
+
+      Object filteringDisabled = args.get("filtering_disabled");
+      if (filteringDisabled != null) this.isFilteringDisabled = Boolean.parseBoolean(filteringDisabled.toString());
 
       Object uriVal = args.get("api_uri");
       URI uri = null;
@@ -35,7 +39,8 @@ public class TraveltimeQParserPlugin extends QParserPlugin {
                                        params,
                                        req,
                                        FetcherSingleton.INSTANCE.getFetcher(),
-                                       cacheName
+                                       cacheName,
+                                       isFilteringDisabled
       );
    }
 

--- a/6/src/main/java/com/traveltime/plugin/solr/query/TraveltimeDelegatingCollector.java
+++ b/6/src/main/java/com/traveltime/plugin/solr/query/TraveltimeDelegatingCollector.java
@@ -38,12 +38,13 @@ public class TraveltimeDelegatingCollector extends DelegatingCollector {
    private final Int2ObjectOpenHashMap<Coordinates> globalDoc2Coords;
    private final ProtoFetcher fetcher;
    private final RequestCache cache;
+   private final boolean isFilteringDisabled;
 
    private Object2IntOpenHashMap<Coordinates> pointToTime;
    private SortedNumericDocValues coords;
 
 
-   public TraveltimeDelegatingCollector(int maxDoc, int segments, TraveltimeQueryParameters params, float scoreWeight, ProtoFetcher fetcher, RequestCache cache) {
+   public TraveltimeDelegatingCollector(int maxDoc, int segments, TraveltimeQueryParameters params, float scoreWeight, ProtoFetcher fetcher, RequestCache cache, boolean isFilteringDisabled) {
       this.maxDoc = maxDoc;
       this.contexts = new LeafReaderContext[segments];
       this.contextBaseStart = new int[segments];
@@ -55,6 +56,7 @@ public class TraveltimeDelegatingCollector extends DelegatingCollector {
       this.scoreWeight = scoreWeight;
       this.fetcher = fetcher;
       this.cache = cache;
+      this.isFilteringDisabled = isFilteringDisabled;
    }
 
    @Override
@@ -134,7 +136,7 @@ public class TraveltimeDelegatingCollector extends DelegatingCollector {
             currentContextIndex++;
          }
 
-         if (pointToTime.containsKey(globalDoc2Coords.get(globalDoc))) {
+         if (isFilteringDisabled || pointToTime.containsKey(globalDoc2Coords.get(globalDoc))) {
             int contextDoc = globalDoc - contextBaseStart[currentContextIndex];
             leafDelegate = delegate.getLeafCollector(contexts[currentContextIndex]);
             leafDelegate.setScorer(forwardingScorer);

--- a/6/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
+++ b/6/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
@@ -14,11 +14,13 @@ public class TraveltimeQueryParser extends QParser {
 
    private final ProtoFetcher fetcher;
    private final String cacheName;
+   private final boolean isFilteringDisabled;
 
-   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, ProtoFetcher fetcher, String cacheName) {
+   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, ProtoFetcher fetcher, String cacheName, boolean isFilteringDisabled) {
       super(qstr, localParams, params, req);
       this.fetcher = fetcher;
       this.cacheName = cacheName;
+      this.isFilteringDisabled = isFilteringDisabled;
    }
 
    private String getBestParam(String name) throws SyntaxError {
@@ -58,7 +60,7 @@ public class TraveltimeQueryParser extends QParser {
             getBestParam(TraveltimeQueryParameters.MODE),
             getBestParam(TraveltimeQueryParameters.COUNTRY)
       );
-      return new TraveltimeSearchQuery(params, weight, fetcher, cacheName);
+      return new TraveltimeSearchQuery(params, weight, fetcher, cacheName, isFilteringDisabled);
    }
 
 }

--- a/6/src/main/java/com/traveltime/plugin/solr/query/TraveltimeSearchQuery.java
+++ b/6/src/main/java/com/traveltime/plugin/solr/query/TraveltimeSearchQuery.java
@@ -17,6 +17,7 @@ public class TraveltimeSearchQuery extends ExtendedQueryBase implements PostFilt
    private final float weight;
    private final ProtoFetcher fetcher;
    private final String cacheName;
+   private final boolean isFilteringDisabled;
 
    @Override
    public String toString(String field) {
@@ -29,7 +30,7 @@ public class TraveltimeSearchQuery extends ExtendedQueryBase implements PostFilt
       RequestCache cache = (RequestCache) searcher.getCache(cacheName);
       int maxDoc = searcher.maxDoc();
       int leafCount = searcher.getTopReaderContext().leaves().size();
-      return new TraveltimeDelegatingCollector(maxDoc, leafCount, params, weight, fetcher, cache);
+      return new TraveltimeDelegatingCollector(maxDoc, leafCount, params, weight, fetcher, cache, isFilteringDisabled);
    }
 
    @Override

--- a/7/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
+++ b/7/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
@@ -14,10 +14,15 @@ public class TraveltimeQParserPlugin extends QParserPlugin {
    public static String PARAM_PREFIX = "traveltime_";
    private String cacheName = RequestCache.NAME;
 
+   private boolean isFilteringDisabled = false;
+
    @Override
    public void init(NamedList args) {
       Object cache = args.get("cache");
       if (cache != null) cacheName = cache.toString();
+
+      Object filteringDisabled = args.get("filtering_disabled");
+      if (filteringDisabled != null) this.isFilteringDisabled = Boolean.parseBoolean(filteringDisabled.toString());
 
       Object uriVal = args.get("api_uri");
       URI uri = null;
@@ -35,7 +40,8 @@ public class TraveltimeQParserPlugin extends QParserPlugin {
                                        params,
                                        req,
                                        FetcherSingleton.INSTANCE.getFetcher(),
-                                       cacheName
+                                       cacheName,
+                                       isFilteringDisabled
       );
    }
 

--- a/7/src/main/java/com/traveltime/plugin/solr/query/TraveltimeDelegatingCollector.java
+++ b/7/src/main/java/com/traveltime/plugin/solr/query/TraveltimeDelegatingCollector.java
@@ -38,12 +38,13 @@ public class TraveltimeDelegatingCollector extends DelegatingCollector {
    private final Int2ObjectOpenHashMap<Coordinates> globalDoc2Coords;
    private final ProtoFetcher fetcher;
    private final RequestCache cache;
+   private final boolean isFilteringDisabled;
 
    private Object2IntOpenHashMap<Coordinates> pointToTime;
    private SortedNumericDocValues coords;
 
 
-   public TraveltimeDelegatingCollector(int maxDoc, int segments, TraveltimeQueryParameters params, float scoreWeight, ProtoFetcher fetcher, RequestCache cache) {
+   public TraveltimeDelegatingCollector(int maxDoc, int segments, TraveltimeQueryParameters params, float scoreWeight, ProtoFetcher fetcher, RequestCache cache, boolean isFilteringDisabled) {
       this.maxDoc = maxDoc;
       this.contexts = new LeafReaderContext[segments];
       this.contextBaseStart = new int[segments];
@@ -55,6 +56,7 @@ public class TraveltimeDelegatingCollector extends DelegatingCollector {
       this.scoreWeight = scoreWeight;
       this.fetcher = fetcher;
       this.cache = cache;
+      this.isFilteringDisabled = isFilteringDisabled;
    }
 
    @Override
@@ -132,7 +134,7 @@ public class TraveltimeDelegatingCollector extends DelegatingCollector {
             currentContextIndex++;
          }
 
-         if (pointToTime.containsKey(globalDoc2Coords.get(globalDoc))) {
+         if (isFilteringDisabled || pointToTime.containsKey(globalDoc2Coords.get(globalDoc))) {
             int contextDoc = globalDoc - contextBaseStart[currentContextIndex];
             leafDelegate = delegate.getLeafCollector(contexts[currentContextIndex]);
             leafDelegate.setScorer(forwardingScorer);

--- a/7/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
+++ b/7/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
@@ -14,11 +14,13 @@ public class TraveltimeQueryParser extends QParser {
 
    private final ProtoFetcher fetcher;
    private final String cacheName;
+   private final boolean isFilteringDisabled;
 
-   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, ProtoFetcher fetcher, String cacheName) {
+   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, ProtoFetcher fetcher, String cacheName, boolean isFilteringDisabled) {
       super(qstr, localParams, params, req);
       this.fetcher = fetcher;
       this.cacheName = cacheName;
+      this.isFilteringDisabled = isFilteringDisabled;
    }
 
    private String getBestParam(String name) throws SyntaxError {
@@ -58,7 +60,7 @@ public class TraveltimeQueryParser extends QParser {
             getBestParam(TraveltimeQueryParameters.MODE),
             getBestParam(TraveltimeQueryParameters.COUNTRY)
       );
-      return new TraveltimeSearchQuery(params, weight, fetcher, cacheName);
+      return new TraveltimeSearchQuery(params, weight, fetcher, cacheName, isFilteringDisabled);
    }
 
 }

--- a/7/src/main/java/com/traveltime/plugin/solr/query/TraveltimeSearchQuery.java
+++ b/7/src/main/java/com/traveltime/plugin/solr/query/TraveltimeSearchQuery.java
@@ -17,6 +17,7 @@ public class TraveltimeSearchQuery extends ExtendedQueryBase implements PostFilt
    private final float weight;
    private final ProtoFetcher fetcher;
    private final String cacheName;
+   private final boolean isFilteringDisabled;
 
    @Override
    public String toString(String field) {
@@ -29,7 +30,7 @@ public class TraveltimeSearchQuery extends ExtendedQueryBase implements PostFilt
       RequestCache cache = (RequestCache) searcher.getCache(cacheName);
       int maxDoc = searcher.maxDoc();
       int leafCount = searcher.getTopReaderContext().leaves().size();
-      return new TraveltimeDelegatingCollector(maxDoc, leafCount, params, weight, fetcher, cache);
+      return new TraveltimeDelegatingCollector(maxDoc, leafCount, params, weight, fetcher, cache, isFilteringDisabled);
    }
 
    @Override

--- a/8/src/main/java/com/traveltime/plugin/solr/TimeFilterQParserPlugin.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/TimeFilterQParserPlugin.java
@@ -15,12 +15,17 @@ import java.util.Optional;
 public class TimeFilterQParserPlugin extends QParserPlugin {
    private String cacheName = RequestCache.NAME;
 
+   private boolean isFilteringDisabled = false;
+
    private static final Integer DEFAULT_LOCATION_SIZE_LIMIT = 2000;
 
    @Override
    public void init(NamedList args) {
       Object cache = args.get("cache");
       if (cache != null) cacheName = cache.toString();
+
+      Object filteringDisabled = args.get("filtering_disabled");
+      if (filteringDisabled != null) this.isFilteringDisabled = Boolean.parseBoolean(filteringDisabled.toString());
 
       Object uriVal = args.get("api_uri");
       URI uri = null;
@@ -43,7 +48,8 @@ public class TimeFilterQParserPlugin extends QParserPlugin {
                                        params,
                                        req,
                                        JsonFetcherSingleton.INSTANCE.getFetcher(),
-                                       cacheName
+                                       cacheName,
+                                       isFilteringDisabled
       );
    }
 

--- a/8/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
@@ -14,10 +14,15 @@ import java.net.URI;
 public class TraveltimeQParserPlugin extends QParserPlugin {
    private String cacheName = RequestCache.NAME;
 
+   private boolean isFilteringDisabled = false;
+
    @Override
    public void init(NamedList args) {
       Object cache = args.get("cache");
       if (cache != null) cacheName = cache.toString();
+
+      Object filteringDisabled = args.get("filtering_disabled");
+      if (filteringDisabled != null) this.isFilteringDisabled = Boolean.parseBoolean(filteringDisabled.toString());
 
       Object uriVal = args.get("api_uri");
       URI uri = null;
@@ -35,7 +40,8 @@ public class TraveltimeQParserPlugin extends QParserPlugin {
                                        params,
                                        req,
                                        ProtoFetcherSingleton.INSTANCE.getFetcher(),
-                                       cacheName
+                                       cacheName,
+                                       isFilteringDisabled
       );
    }
 

--- a/8/src/main/java/com/traveltime/plugin/solr/query/TraveltimeDelegatingCollector.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/query/TraveltimeDelegatingCollector.java
@@ -37,12 +37,13 @@ public class TraveltimeDelegatingCollector<Params extends QueryParams> extends D
    private final Int2ObjectOpenHashMap<Coordinates> globalDoc2Coords;
    private final Fetcher<Params> fetcher;
    private final RequestCache<Params> cache;
+   private final boolean isFilteringDisabled;
 
    private Object2IntOpenHashMap<Coordinates> pointToTime;
    private SortedNumericDocValues coords;
 
 
-   public TraveltimeDelegatingCollector(int maxDoc, int segments, Params params, float scoreWeight, Fetcher<Params> fetcher, RequestCache<Params> cache) {
+   public TraveltimeDelegatingCollector(int maxDoc, int segments, Params params, float scoreWeight, Fetcher<Params> fetcher, RequestCache<Params> cache, boolean isFilteringDisabled) {
       this.maxDoc = maxDoc;
       this.contexts = new LeafReaderContext[segments];
       this.contextBaseStart = new int[segments];
@@ -54,6 +55,7 @@ public class TraveltimeDelegatingCollector<Params extends QueryParams> extends D
       this.scoreWeight = scoreWeight;
       this.fetcher = fetcher;
       this.cache = cache;
+      this.isFilteringDisabled = isFilteringDisabled;
    }
 
    @Override
@@ -120,7 +122,7 @@ public class TraveltimeDelegatingCollector<Params extends QueryParams> extends D
             currentContextIndex++;
          }
 
-         if (pointToTime.containsKey(globalDoc2Coords.get(globalDoc))) {
+         if (isFilteringDisabled || pointToTime.containsKey(globalDoc2Coords.get(globalDoc))) {
             int contextDoc = globalDoc - contextBaseStart[currentContextIndex];
             leafDelegate = delegate.getLeafCollector(contexts[currentContextIndex]);
             leafDelegate.setScorer(forwardingScorer);

--- a/8/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
@@ -12,11 +12,13 @@ public class TraveltimeQueryParser extends QParser {
 
    private final Fetcher<TraveltimeQueryParameters> fetcher;
    private final String cacheName;
+   private final boolean isFilteringDisabled;
 
-   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, Fetcher<TraveltimeQueryParameters> fetcher, String cacheName) {
+   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, Fetcher<TraveltimeQueryParameters> fetcher, String cacheName, boolean isFilteringDisabled) {
       super(qstr, localParams, params, req);
       this.fetcher = fetcher;
       this.cacheName = cacheName;
+      this.isFilteringDisabled = isFilteringDisabled;
    }
 
    @Override
@@ -35,7 +37,7 @@ public class TraveltimeQueryParser extends QParser {
       }
 
       val params = TraveltimeQueryParameters.parse(req.getSchema(), paramSource);
-      return new TraveltimeSearchQuery<>(params, weight, fetcher, cacheName);
+      return new TraveltimeSearchQuery<>(params, weight, fetcher, cacheName, isFilteringDisabled);
    }
 
 }

--- a/8/src/main/java/com/traveltime/plugin/solr/query/TraveltimeSearchQuery.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/query/TraveltimeSearchQuery.java
@@ -17,6 +17,7 @@ public class TraveltimeSearchQuery<Params extends QueryParams> extends ExtendedQ
    private final float weight;
    private final Fetcher<Params> fetcher;
    private final String cacheName;
+   private final boolean isFilteringDisabled;
 
    @Override
    public String toString(String field) {
@@ -29,7 +30,7 @@ public class TraveltimeSearchQuery<Params extends QueryParams> extends ExtendedQ
       RequestCache<Params> cache = (RequestCache<Params>) searcher.getCache(cacheName);
       int maxDoc = searcher.maxDoc();
       int leafCount = searcher.getTopReaderContext().leaves().size();
-      return new TraveltimeDelegatingCollector<>(maxDoc, leafCount, params, weight, fetcher, cache);
+      return new TraveltimeDelegatingCollector<>(maxDoc, leafCount, params, weight, fetcher, cache, isFilteringDisabled);
    }
 
    @Override

--- a/8/src/main/java/com/traveltime/plugin/solr/query/timefilter/TimeFilterQueryParser.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/query/timefilter/TimeFilterQueryParser.java
@@ -14,11 +14,13 @@ public class TimeFilterQueryParser extends QParser {
 
    private final Fetcher<TimeFilterQueryParameters> fetcher;
    private final String cacheName;
+   private final boolean isFilteringDisabled;
 
-   public TimeFilterQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, Fetcher<TimeFilterQueryParameters> fetcher, String cacheName) {
+   public TimeFilterQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, Fetcher<TimeFilterQueryParameters> fetcher, String cacheName, boolean isFilteringDisabled) {
       super(qstr, localParams, params, req);
       this.fetcher = fetcher;
       this.cacheName = cacheName;
+      this.isFilteringDisabled = isFilteringDisabled;
    }
 
    @Override
@@ -37,7 +39,7 @@ public class TimeFilterQueryParser extends QParser {
       }
 
       val params = TimeFilterQueryParameters.parse(req.getSchema(), paramSource);
-      return new TraveltimeSearchQuery<>(params, weight, fetcher, cacheName);
+      return new TraveltimeSearchQuery<>(params, weight, fetcher, cacheName, isFilteringDisabled);
    }
 
 }

--- a/9/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
+++ b/9/src/main/java/com/traveltime/plugin/solr/TraveltimeQParserPlugin.java
@@ -14,10 +14,15 @@ public class TraveltimeQParserPlugin extends QParserPlugin {
    public static String PARAM_PREFIX = "traveltime_";
    private String cacheName = RequestCache.NAME;
 
+   private boolean isFilteringDisabled = false;
+
    @Override
    public void init(NamedList args) {
       Object cache = args.get("cache");
       if (cache != null) cacheName = cache.toString();
+
+      Object filteringDisabled = args.get("filtering_disabled");
+      if (filteringDisabled != null) this.isFilteringDisabled = Boolean.parseBoolean(filteringDisabled.toString());
 
       Object uriVal = args.get("api_uri");
       URI uri = null;
@@ -35,7 +40,8 @@ public class TraveltimeQParserPlugin extends QParserPlugin {
                                        params,
                                        req,
                                        FetcherSingleton.INSTANCE.getFetcher(),
-                                       cacheName
+                                       cacheName,
+                                       isFilteringDisabled
       );
    }
 

--- a/9/src/main/java/com/traveltime/plugin/solr/query/TraveltimeDelegatingCollector.java
+++ b/9/src/main/java/com/traveltime/plugin/solr/query/TraveltimeDelegatingCollector.java
@@ -38,12 +38,13 @@ public class TraveltimeDelegatingCollector extends DelegatingCollector {
    private final Int2ObjectOpenHashMap<Coordinates> globalDoc2Coords;
    private final ProtoFetcher fetcher;
    private final RequestCache cache;
+   private final boolean isFilteringDisabled;
 
    private Object2IntOpenHashMap<Coordinates> pointToTime;
    private SortedNumericDocValues coords;
 
 
-   public TraveltimeDelegatingCollector(int maxDoc, int segments, TraveltimeQueryParameters params, float scoreWeight, ProtoFetcher fetcher, RequestCache cache) {
+   public TraveltimeDelegatingCollector(int maxDoc, int segments, TraveltimeQueryParameters params, float scoreWeight, ProtoFetcher fetcher, RequestCache cache, boolean isFilteringDisabled) {
       this.maxDoc = maxDoc;
       this.contexts = new LeafReaderContext[segments];
       this.contextBaseStart = new int[segments];
@@ -55,6 +56,7 @@ public class TraveltimeDelegatingCollector extends DelegatingCollector {
       this.scoreWeight = scoreWeight;
       this.fetcher = fetcher;
       this.cache = cache;
+      this.isFilteringDisabled = isFilteringDisabled;
    }
 
    @Override
@@ -127,7 +129,7 @@ public class TraveltimeDelegatingCollector extends DelegatingCollector {
             currentContextIndex++;
          }
 
-         if (pointToTime.containsKey(globalDoc2Coords.get(globalDoc))) {
+         if (isFilteringDisabled || pointToTime.containsKey(globalDoc2Coords.get(globalDoc))) {
             int contextDoc = globalDoc - contextBaseStart[currentContextIndex];
             leafDelegate = delegate.getLeafCollector(contexts[currentContextIndex]);
             leafDelegate.setScorer(forwardingScorer);

--- a/9/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
+++ b/9/src/main/java/com/traveltime/plugin/solr/query/TraveltimeQueryParser.java
@@ -14,11 +14,13 @@ public class TraveltimeQueryParser extends QParser {
 
    private final ProtoFetcher fetcher;
    private final String cacheName;
+   private final boolean isFilteringDisabled;
 
-   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, ProtoFetcher fetcher, String cacheName) {
+   public TraveltimeQueryParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, ProtoFetcher fetcher, String cacheName, boolean isFilteringDisabled) {
       super(qstr, localParams, params, req);
       this.fetcher = fetcher;
       this.cacheName = cacheName;
+      this.isFilteringDisabled = isFilteringDisabled;
    }
 
    private String getBestParam(String name) throws SyntaxError {
@@ -58,7 +60,7 @@ public class TraveltimeQueryParser extends QParser {
             getBestParam(TraveltimeQueryParameters.MODE),
             getBestParam(TraveltimeQueryParameters.COUNTRY)
       );
-      return new TraveltimeSearchQuery(params, weight, fetcher, cacheName);
+      return new TraveltimeSearchQuery(params, weight, fetcher, cacheName, isFilteringDisabled);
    }
 
 }

--- a/9/src/main/java/com/traveltime/plugin/solr/query/TraveltimeSearchQuery.java
+++ b/9/src/main/java/com/traveltime/plugin/solr/query/TraveltimeSearchQuery.java
@@ -18,6 +18,7 @@ public class TraveltimeSearchQuery extends ExtendedQueryBase implements PostFilt
    private final float weight;
    private final ProtoFetcher fetcher;
    private final String cacheName;
+   private final boolean isFilteringDisabled;
 
    @Override
    public String toString(String field) {
@@ -35,7 +36,7 @@ public class TraveltimeSearchQuery extends ExtendedQueryBase implements PostFilt
       RequestCache cache = (RequestCache) searcher.getCache(cacheName);
       int maxDoc = searcher.maxDoc();
       int leafCount = searcher.getTopReaderContext().leaves().size();
-      return new TraveltimeDelegatingCollector(maxDoc, leafCount, params, weight, fetcher, cache);
+      return new TraveltimeDelegatingCollector(maxDoc, leafCount, params, weight, fetcher, cache, isFilteringDisabled);
    }
 
    @Override


### PR DESCRIPTION
Add an option do disable filtering, so that when using multiple filters the search results are not limited to the intersection of all filters.

By disabling the filtering, the travel times will be retrieved and are available for display for all documents of the original Solr query.

This change is backwards compatible.