### PR TITLE
Override getDescription() in cache classes to display plugin-specific…

### DIFF
--- a/6/src/main/java/com/traveltime/plugin/solr/cache/ExactRequestCache.java
+++ b/6/src/main/java/com/traveltime/plugin/solr/cache/ExactRequestCache.java
@@ -8,4 +8,9 @@ import lombok.Getter;
 public class ExactRequestCache extends RequestCache<TravelTimeQueryParameters> {
   private final UnadaptedRequestCache<TravelTimeQueryParameters> unadapted =
       new UnadaptedRequestCache<>(this::get, this::put, Function.identity(), BasicCachedData::new);
+
+  @Override
+  public String getDescription() {
+    return "TravelTime ExactRequestCache - " + super.getDescription();
+  }
 }

--- a/6/src/main/java/com/traveltime/plugin/solr/cache/ExactTimeFilterRequestCache.java
+++ b/6/src/main/java/com/traveltime/plugin/solr/cache/ExactTimeFilterRequestCache.java
@@ -8,4 +8,9 @@ import lombok.Getter;
 public class ExactTimeFilterRequestCache extends RequestCache<TimeFilterQueryParameters> {
   private final UnadaptedRequestCache<TimeFilterQueryParameters> unadapted =
       new UnadaptedRequestCache<>(this::get, this::put, Function.identity(), BasicCachedData::new);
+
+  @Override
+  public String getDescription() {
+    return "TravelTime ExactTimeFilterRequestCache - " + super.getDescription();
+  }
 }

--- a/6/src/main/java/com/traveltime/plugin/solr/cache/FuzzyRequestCache.java
+++ b/6/src/main/java/com/traveltime/plugin/solr/cache/FuzzyRequestCache.java
@@ -21,4 +21,11 @@ public class FuzzyRequestCache extends RequestCache<TravelTimeQueryParameters> {
           this::put,
           TravelTimeQueryParameters::fuzzy,
           () -> new LRUData(args, AdaptedCacheImpl::new));
+
+  @Override
+  public String getDescription() {
+    return String.format(
+        "TravelTime FuzzyRequestCache(secondary_size=%s) - %s",
+        LRUData.getSecondarySize(args), super.getDescription());
+  }
 }

--- a/6/src/main/java/com/traveltime/plugin/solr/cache/FuzzyTimeFilterRequestCache.java
+++ b/6/src/main/java/com/traveltime/plugin/solr/cache/FuzzyTimeFilterRequestCache.java
@@ -21,4 +21,11 @@ public class FuzzyTimeFilterRequestCache extends RequestCache<TimeFilterQueryPar
           this::put,
           TimeFilterQueryParameters::fuzzy,
           () -> new LRUData(args, AdaptedCacheImpl::new));
+
+  @Override
+  public String getDescription() {
+    return String.format(
+        "TravelTime FuzzyTimeFilterRequestCache(secondary_size=%s) - %s",
+        LRUData.getSecondarySize(args), super.getDescription());
+  }
 }

--- a/7/src/main/java/com/traveltime/plugin/solr/cache/ExactRequestCache.java
+++ b/7/src/main/java/com/traveltime/plugin/solr/cache/ExactRequestCache.java
@@ -8,4 +8,9 @@ import lombok.Getter;
 public class ExactRequestCache extends RequestCache<TravelTimeQueryParameters> {
   private final UnadaptedRequestCache<TravelTimeQueryParameters> unadapted =
       new UnadaptedRequestCache<>(this::get, this::put, Function.identity(), BasicCachedData::new);
+
+  @Override
+  public String getDescription() {
+    return "TravelTime ExactRequestCache - " + super.getDescription();
+  }
 }

--- a/7/src/main/java/com/traveltime/plugin/solr/cache/ExactTimeFilterRequestCache.java
+++ b/7/src/main/java/com/traveltime/plugin/solr/cache/ExactTimeFilterRequestCache.java
@@ -8,4 +8,9 @@ import lombok.Getter;
 public class ExactTimeFilterRequestCache extends RequestCache<TimeFilterQueryParameters> {
   private final UnadaptedRequestCache<TimeFilterQueryParameters> unadapted =
       new UnadaptedRequestCache<>(this::get, this::put, Function.identity(), BasicCachedData::new);
+
+  @Override
+  public String getDescription() {
+    return "TravelTime ExactTimeFilterRequestCache - " + super.getDescription();
+  }
 }

--- a/7/src/main/java/com/traveltime/plugin/solr/cache/FuzzyRequestCache.java
+++ b/7/src/main/java/com/traveltime/plugin/solr/cache/FuzzyRequestCache.java
@@ -21,4 +21,11 @@ public class FuzzyRequestCache extends RequestCache<TravelTimeQueryParameters> {
           this::put,
           TravelTimeQueryParameters::fuzzy,
           () -> new LRUData(args, AdaptedCacheImpl::new));
+
+  @Override
+  public String getDescription() {
+    return String.format(
+        "TravelTime FuzzyRequestCache(secondary_size=%s) - %s",
+        LRUData.getSecondarySize(args), super.getDescription());
+  }
 }

--- a/7/src/main/java/com/traveltime/plugin/solr/cache/FuzzyTimeFilterRequestCache.java
+++ b/7/src/main/java/com/traveltime/plugin/solr/cache/FuzzyTimeFilterRequestCache.java
@@ -21,4 +21,11 @@ public class FuzzyTimeFilterRequestCache extends RequestCache<TimeFilterQueryPar
           this::put,
           TimeFilterQueryParameters::fuzzy,
           () -> new LRUData(args, AdaptedCacheImpl::new));
+
+  @Override
+  public String getDescription() {
+    return String.format(
+        "TravelTime FuzzyTimeFilterRequestCache(secondary_size=%s) - %s",
+        LRUData.getSecondarySize(args), super.getDescription());
+  }
 }

--- a/8/src/main/java/com/traveltime/plugin/solr/cache/ExactRequestCache.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/cache/ExactRequestCache.java
@@ -8,4 +8,9 @@ import lombok.Getter;
 public class ExactRequestCache extends RequestCache<TravelTimeQueryParameters> {
   private final UnadaptedRequestCache<TravelTimeQueryParameters> unadapted =
       new UnadaptedRequestCache<>(this::get, this::put, Function.identity(), BasicCachedData::new);
+
+  @Override
+  public String getDescription() {
+    return "TravelTime ExactRequestCache - " + super.getDescription();
+  }
 }

--- a/8/src/main/java/com/traveltime/plugin/solr/cache/ExactTimeFilterRequestCache.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/cache/ExactTimeFilterRequestCache.java
@@ -8,4 +8,9 @@ import lombok.Getter;
 public class ExactTimeFilterRequestCache extends RequestCache<TimeFilterQueryParameters> {
   private final UnadaptedRequestCache<TimeFilterQueryParameters> unadapted =
       new UnadaptedRequestCache<>(this::get, this::put, Function.identity(), BasicCachedData::new);
+
+  @Override
+  public String getDescription() {
+    return "TravelTime ExactTimeFilterRequestCache - " + super.getDescription();
+  }
 }

--- a/8/src/main/java/com/traveltime/plugin/solr/cache/FuzzyRequestCache.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/cache/FuzzyRequestCache.java
@@ -21,4 +21,11 @@ public class FuzzyRequestCache extends RequestCache<TravelTimeQueryParameters> {
           this::put,
           TravelTimeQueryParameters::fuzzy,
           () -> new LRUData(args, AdaptedCacheImpl::new));
+
+  @Override
+  public String getDescription() {
+    return String.format(
+        "TravelTime FuzzyRequestCache(secondary_size=%s) - %s",
+        LRUData.getSecondarySize(args), super.getDescription());
+  }
 }

--- a/8/src/main/java/com/traveltime/plugin/solr/cache/FuzzyTimeFilterRequestCache.java
+++ b/8/src/main/java/com/traveltime/plugin/solr/cache/FuzzyTimeFilterRequestCache.java
@@ -21,4 +21,11 @@ public class FuzzyTimeFilterRequestCache extends RequestCache<TimeFilterQueryPar
           this::put,
           TimeFilterQueryParameters::fuzzy,
           () -> new LRUData(args, AdaptedCacheImpl::new));
+
+  @Override
+  public String getDescription() {
+    return String.format(
+        "TravelTime FuzzyTimeFilterRequestCache(secondary_size=%s) - %s",
+        LRUData.getSecondarySize(args), super.getDescription());
+  }
 }

--- a/9.0-3/src/main/java/com/traveltime/plugin/solr/cache/ExactRequestCache.java
+++ b/9.0-3/src/main/java/com/traveltime/plugin/solr/cache/ExactRequestCache.java
@@ -8,4 +8,9 @@ import lombok.Getter;
 public class ExactRequestCache extends RequestCache<TravelTimeQueryParameters> {
   private final UnadaptedRequestCache<TravelTimeQueryParameters> unadapted =
       new UnadaptedRequestCache<>(this::get, this::put, Function.identity(), BasicCachedData::new);
+
+  @Override
+  public String getDescription() {
+    return "TravelTime ExactRequestCache - " + super.getDescription();
+  }
 }

--- a/9.0-3/src/main/java/com/traveltime/plugin/solr/cache/ExactTimeFilterRequestCache.java
+++ b/9.0-3/src/main/java/com/traveltime/plugin/solr/cache/ExactTimeFilterRequestCache.java
@@ -8,4 +8,9 @@ import lombok.Getter;
 public class ExactTimeFilterRequestCache extends RequestCache<TimeFilterQueryParameters> {
   private final UnadaptedRequestCache<TimeFilterQueryParameters> unadapted =
       new UnadaptedRequestCache<>(this::get, this::put, Function.identity(), BasicCachedData::new);
+
+  @Override
+  public String getDescription() {
+    return "TravelTime ExactTimeFilterRequestCache - " + super.getDescription();
+  }
 }

--- a/9.0-3/src/main/java/com/traveltime/plugin/solr/cache/FuzzyRequestCache.java
+++ b/9.0-3/src/main/java/com/traveltime/plugin/solr/cache/FuzzyRequestCache.java
@@ -21,4 +21,11 @@ public class FuzzyRequestCache extends RequestCache<TravelTimeQueryParameters> {
           this::put,
           TravelTimeQueryParameters::fuzzy,
           () -> new LRUData(args, AdaptedCacheImpl::new));
+
+  @Override
+  public String getDescription() {
+    return String.format(
+        "TravelTime FuzzyRequestCache(secondary_size=%s) - %s",
+        LRUData.getSecondarySize(args), super.getDescription());
+  }
 }

--- a/9.0-3/src/main/java/com/traveltime/plugin/solr/cache/FuzzyTimeFilterRequestCache.java
+++ b/9.0-3/src/main/java/com/traveltime/plugin/solr/cache/FuzzyTimeFilterRequestCache.java
@@ -21,4 +21,11 @@ public class FuzzyTimeFilterRequestCache extends RequestCache<TimeFilterQueryPar
           this::put,
           TimeFilterQueryParameters::fuzzy,
           () -> new LRUData(args, AdaptedCacheImpl::new));
+
+  @Override
+  public String getDescription() {
+    return String.format(
+        "TravelTime FuzzyTimeFilterRequestCache(secondary_size=%s) - %s",
+        LRUData.getSecondarySize(args), super.getDescription());
+  }
 }

--- a/9.4/src/main/java/com/traveltime/plugin/solr/cache/ExactRequestCache.java
+++ b/9.4/src/main/java/com/traveltime/plugin/solr/cache/ExactRequestCache.java
@@ -8,4 +8,9 @@ import lombok.Getter;
 public class ExactRequestCache extends RequestCache<TravelTimeQueryParameters> {
   private final UnadaptedRequestCache<TravelTimeQueryParameters> unadapted =
       new UnadaptedRequestCache<>(this::get, this::put, Function.identity(), BasicCachedData::new);
+
+  @Override
+  public String getDescription() {
+    return "TravelTime ExactRequestCache - " + super.getDescription();
+  }
 }

--- a/9.4/src/main/java/com/traveltime/plugin/solr/cache/ExactTimeFilterRequestCache.java
+++ b/9.4/src/main/java/com/traveltime/plugin/solr/cache/ExactTimeFilterRequestCache.java
@@ -8,4 +8,9 @@ import lombok.Getter;
 public class ExactTimeFilterRequestCache extends RequestCache<TimeFilterQueryParameters> {
   private final UnadaptedRequestCache<TimeFilterQueryParameters> unadapted =
       new UnadaptedRequestCache<>(this::get, this::put, Function.identity(), BasicCachedData::new);
+
+  @Override
+  public String getDescription() {
+    return "TravelTime ExactTimeFilterRequestCache - " + super.getDescription();
+  }
 }

--- a/9.4/src/main/java/com/traveltime/plugin/solr/cache/FuzzyRequestCache.java
+++ b/9.4/src/main/java/com/traveltime/plugin/solr/cache/FuzzyRequestCache.java
@@ -21,4 +21,11 @@ public class FuzzyRequestCache extends RequestCache<TravelTimeQueryParameters> {
           this::put,
           TravelTimeQueryParameters::fuzzy,
           () -> new LRUData(args, AdaptedCacheImpl::new));
+
+  @Override
+  public String getDescription() {
+    return String.format(
+        "TravelTime FuzzyRequestCache(secondary_size=%s) - %s",
+        LRUData.getSecondarySize(args), super.getDescription());
+  }
 }

--- a/9.4/src/main/java/com/traveltime/plugin/solr/cache/FuzzyTimeFilterRequestCache.java
+++ b/9.4/src/main/java/com/traveltime/plugin/solr/cache/FuzzyTimeFilterRequestCache.java
@@ -21,4 +21,11 @@ public class FuzzyTimeFilterRequestCache extends RequestCache<TimeFilterQueryPar
           this::put,
           TimeFilterQueryParameters::fuzzy,
           () -> new LRUData(args, AdaptedCacheImpl::new));
+
+  @Override
+  public String getDescription() {
+    return String.format(
+        "TravelTime FuzzyTimeFilterRequestCache(secondary_size=%s) - %s",
+        LRUData.getSecondarySize(args), super.getDescription());
+  }
 }

--- a/common/src/main/java/com/traveltime/plugin/solr/cache/LRUData.java
+++ b/common/src/main/java/com/traveltime/plugin/solr/cache/LRUData.java
@@ -12,16 +12,19 @@ import java.util.function.Supplier;
 import lombok.val;
 
 public class LRUData extends CachedData {
+  public static final String SECONDARY_SIZE_PARAM = "secondary_size";
+  public static final String DEFAULT_SECONDARY_SIZE = "10000";
+
+  public static String getSecondarySize(Map<String, String> args) {
+    return args.getOrDefault(SECONDARY_SIZE_PARAM, DEFAULT_SECONDARY_SIZE);
+  }
+
   private final AdaptedCache<Coordinates, Integer> coordsToTimes;
 
   public LRUData(
       Map<String, String> args, Supplier<AdaptedCache<Coordinates, Integer>> cacheSupplier) {
     args.putIfAbsent("name", "fuzzy_cache");
-    String size = args.get("secondary_size");
-    if (size == null) {
-      size = "10000";
-    }
-    args.put("size", size);
+    args.put("size", getSecondarySize(args));
 
     coordsToTimes = cacheSupplier.get();
     coordsToTimes.init(args);


### PR DESCRIPTION
… info

Fuzzy caches now show secondary_size, and all caches include the parent cache description with maxSize/initialSize. Also extracts the secondary_size default into LRUData for consistency.